### PR TITLE
Substituição de função obsoleta

### DIFF
--- a/public/class-wc-parcelas-public.php
+++ b/public/class-wc-parcelas-public.php
@@ -85,7 +85,7 @@ class Woocommerce_Parcelas_Public extends Woocommerce_Parcelas_Meta_Box {
 		 */
 		$class = 'loop';
 
-		if ( ! wc_get_price_including_tax( $product ) ) {
+		if ( ! wc_custom_get_price() ) {
 			return;
 		}
 


### PR DESCRIPTION
Alterada função wc_get_price_including_tax($product) por wc_custom_get_price() para suprimir alerta de função obsoleta.