### PR TITLE
Substituição de função obsoleta

### DIFF
--- a/public/in-cash-calc.php
+++ b/public/in-cash-calc.php
@@ -42,7 +42,7 @@ if ( 'variable' == $product->get_type() ) {
  *
  * @var     string $price
  */
-$price = wc_get_price_including_tax( $product );
+$price = wc_custom_get_price();
 
 $factor = str_replace( ',', '.', $discount_value );
 


### PR DESCRIPTION
Alterada função wc_get_price_including_tax($product) por wc_custom_get_price() para suprimir alerta de função obsoleta.