### PR TITLE
Substituição de função obsoleta

### DIFF
--- a/public/installments-calc.php
+++ b/public/installments-calc.php
@@ -58,7 +58,7 @@ if ( 'variable' == $product->get_type() ) {
  *
  * @var     string $price
  */
-$price = wc_get_price_including_tax( $product );
+$price = wc_custom_get_price();
 
 if ( $price <= $min_value ) {
 	$installments_html = '';


### PR DESCRIPTION
Alterada função wc_get_price_including_tax($product) por wc_custom_get_price() para suprimir alerta de função obsoleta.