### PR TITLE
Adição da Posição 'woocommerce_get_price_html'

### DIFF
--- a/admin/class-wc-parcelas-settings.php
+++ b/admin/class-wc-parcelas-settings.php
@@ -274,7 +274,8 @@ class Woocommerce_Parcelas_Settings {
 					'id'      => 'fswp_in_loop_position',
 					'options' => array(
 						'woocommerce_after_shop_loop_item_title' => 'Posição 1',
-						'woocommerce_after_shop_loop_item'       => 'Posição 2'
+						'woocommerce_after_shop_loop_item'       => 'Posição 2',
+						'woocommerce_get_price_html'             => 'Posição 3'
 					),
 					'desc'    => __( 'Defina a posição das parcelas, dentro das páginas que listam os produtos, e a prioridade dessa posição abaixo. Padrão: 1.',
 						'wc-parcelas' ),


### PR DESCRIPTION
Adiciona a opção de exibir as opções de pagamento abaixo do preço do produto