### PR TITLE
Implementação de possibilidade de sobreescrita de quantidade de parcelas e preço à vista por produto

### DIFF
--- a/admin/class-wc-parcelas-meta-box.php
+++ b/admin/class-wc-parcelas-meta-box.php
@@ -14,16 +14,26 @@ class Woocommerce_Parcelas_Meta_Box extends Woocommerce_Parcelas_Settings {
 	 * @var     string $fswp_post_meta_key
 	 */
 	public $fswp_post_meta_key = 'fswp_post_meta';
-
 	/**
 	 * @var     string $disable_in_cash_key
 	 */
 	public $disable_in_cash_key = 'disable_in_cash';
-
+	/**
+	 * @var     string $custom_in_cash_discount_type_key
+	 */
+	public $custom_in_cash_discount_type_key = 'in_cash_discount_type';	
+	/**
+	 * @var     string $custom_in_cash_discount_key
+	 */
+	public $custom_in_cash_discount_key = 'in_cash_discount';
 	/**
 	 * @var     string $disable_installments_key
 	 */
 	public $disable_installments_key = 'disable_installments';
+	/**
+	 * @var     string $custom_installment_qty_key
+	 */
+	public $custom_installment_qty_key = 'installment_qty';
 
 	public function __construct() {
 		/**
@@ -44,42 +54,62 @@ class Woocommerce_Parcelas_Meta_Box extends Woocommerce_Parcelas_Settings {
 			array( $this, 'fswp_product_meta_box_callback' ),
 			'product',
 			'normal',
-			'low',
-			array(
-				'values' => array(
-					$this->disable_in_cash_key      => __( 'Desativar preço à vista para este produto', 'wc-parcelas' ),
-					$this->disable_installments_key => __( 'Desativar preço parcelado para este produto', 'wc-parcelas' )
-				)
-			)
+			'low'
 		);
 	}
 
 	public function fswp_product_meta_box_callback( $post, $metabox ) {
 		wp_nonce_field( 'fswp_product_meta_box_nonce_context', 'fswp_product_meta_box_nonce_name' );
-
-		foreach ( $metabox['args']['values'] as $value => $label ) {
-			echo "<p>";
-			echo "<input type='hidden' name='$this->fswp_post_meta_key[$value]' value='0' />";
-			echo "<input type='checkbox' id='$this->fswp_post_meta_key[$value]' name='$this->fswp_post_meta_key[$value]' value='1' " . checked( 1, $this->get_fswp_post_meta_data( $value ), false ) . " />";
-			echo "<label for='$this->fswp_post_meta_key[$value]'>" . $label . "</label>";
-			echo "</p>";
-		}
+		// Disable in cash for this product field
+		echo "<p>";
+			echo "<input type='hidden' name='$this->fswp_post_meta_key[$this->disable_in_cash_key]' value='0' />";
+			echo "<input type='checkbox' id='$this->fswp_post_meta_key[$this->disable_in_cash_key]' name='$this->fswp_post_meta_key[$this->disable_in_cash_key]' value='1' " . checked( 1, $this->get_fswp_post_meta_data($this->disable_in_cash_key ), false ) . " />";
+			echo "<label for='$this->fswp_post_meta_key[$this->disable_in_cash_key]'>" . __('Desativar preço à vista para este produto', 'wc-parcelas') . "</label>";
+		echo "</p>";
+		// Overwrite in cash discount type field
+		$in_cash_discount_type = isset($this->settings[$this->custom_in_cash_discount_type_key]) ? $this->settings[$this->custom_in_cash_discount_type_key] : 0;
+		$in_cash_discount_type_selected = $this->get_fswp_post_meta_data($this->custom_in_cash_discount_type_key) ?: $in_cash_discount_type;
+		echo "<p>";
+			echo "<label for='$this->fswp_post_meta_key[$this->custom_in_cash_discount_type_key]'>" . __('Sobreescrever o tipo de desconto à vista global', 'wc-parcelas') . ":</label> ";
+			echo "<select id='$this->fswp_post_meta_key[$this->custom_in_cash_discount_type_key]' name='$this->fswp_post_meta_key[$this->custom_in_cash_discount_type_key]'>";
+				echo "<option value='0' " . selected($in_cash_discount_type_selected, 0, false ) . ">" . '%' . ($in_cash_discount_type==0 ? ' ('. __('global', 'wc-parcelas') . ')' : '') . "</option>";
+				echo "<option value='1' " . selected($in_cash_discount_type_selected, 1, false ) . ">" . __('fixo', 'wc-parcelas') . ($in_cash_discount_type == 1 ? ' (' . __('global', 'wc-parcelas') . ')' : '') . "</option>";
+			echo "</select>";
+		echo "</p>";
+		// Overwrite in cash discount field
+		$in_cash_discount = isset($this->settings[$this->custom_in_cash_discount_key]) ? $this->settings[$this->custom_in_cash_discount_key] : false;
+		echo "<p>";
+			echo "<label for='$this->fswp_post_meta_key[$this->custom_in_cash_discount_key]'>" . __('Sobreescrever o desconto à vista global', 'wc-parcelas') . ":</label> ";
+			echo "<input type='number' id='$this->fswp_post_meta_key[$this->custom_in_cash_discount_key]' name='$this->fswp_post_meta_key[$this->custom_in_cash_discount_key]' value='" . $this->get_fswp_post_meta_data($this->custom_in_cash_discount_key) . "' min='0' step='0.01' placeholder='". $in_cash_discount ."' />";
+		echo "</p>";
+		// Disable installments for this product field
+		echo "<p>";
+			echo "<input type='hidden' name='$this->fswp_post_meta_key[$this->disable_installments_key]' value='0' />";
+			echo "<input type='checkbox' id='$this->fswp_post_meta_key[$this->disable_installments_key]' name='$this->fswp_post_meta_key[$this->disable_installments_key]' value='1' " . checked( 1, $this->get_fswp_post_meta_data($this->disable_installments_key ), false ) . " />";
+			echo "<label for='$this->fswp_post_meta_key[$this->disable_installments_key]'>" . __('Desativar preço parcelado para este produto', 'wc-parcelas') . "</label>";
+		echo "</p>";
+		// Overwrite installments qty field
+		$installment_qty = isset($this->settings[$this->custom_installment_qty_key]) ? $this->settings[$this->custom_installment_qty_key] : false;
+		echo "<p>";
+			echo "<label for='$this->fswp_post_meta_key[$this->custom_installment_qty_key]'>" . __('Sobreescrever a quantidade de parcelas global', 'wc-parcelas') . ":</label> ";
+			echo "<input type='number' id='$this->fswp_post_meta_key[$this->custom_installment_qty_key]' name='$this->fswp_post_meta_key[$this->custom_installment_qty_key]' value='" . $this->get_fswp_post_meta_data($this->custom_installment_qty_key) . "' min='0' step='1' placeholder='". $installment_qty ."' />";
+		echo "</p>";
 	}
 
 	/**
 	 * Get fswp post meta value
 	 *
-	 * @param  string  $value  meta_value name
+	 * @param  string  $field  meta_value name
 	 *
-	 * @return  string  $fswp_post_meta_data[$value]    meta_value value
+	 * @return  string  $fswp_post_meta_data[$field]    meta_value field
 	 */
-	public function get_fswp_post_meta_data( $value ) {
+	public function get_fswp_post_meta_data( $field ) {
 		$post_id = get_the_ID();
 
 		if ( null != get_post_meta( $post_id, $this->fswp_post_meta_key ) ) {
 			$fswp_post_meta_data = get_post_meta( $post_id, $this->fswp_post_meta_key, true );
 
-			return $fswp_post_meta_data[ $value ];
+			return isset($fswp_post_meta_data[$field]) ? $fswp_post_meta_data[$field] : false;
 		}
 
 		return false;

--- a/admin/class-wc-parcelas-settings.php
+++ b/admin/class-wc-parcelas-settings.php
@@ -243,7 +243,7 @@ class Woocommerce_Parcelas_Settings {
 					'id'      => 'in_cash_discount_type',
 					'options' => array(
 						0 => '%',
-						1 => 'fixo'
+						1 => __('fixo', 'wc-parcelas')
 					),
 					'desc'    => __( 'Quer descontar uma porcentagem ou um valor fixo?', 'wc-parcelas' ),
 					'default' => ''

--- a/public/class-wc-parcelas-public.php
+++ b/public/class-wc-parcelas-public.php
@@ -85,7 +85,7 @@ class Woocommerce_Parcelas_Public extends Woocommerce_Parcelas_Meta_Box {
 		 */
 		$class = 'loop';
 
-		if ( ! wc_get_price_including_tax() ) {
+		if ( !wc_get_price_including_tax($product)) {
 			return;
 		}
 
@@ -187,10 +187,12 @@ class Woocommerce_Parcelas_Public extends Woocommerce_Parcelas_Meta_Box {
 	 *
 	 * @return  void
 	 */
-	public function fswp_variable_installment_calculation() { ?>
+	public function fswp_variable_installment_calculation() {
+		// Get get_fswp_post_meta_data for installment qty overwrite
+		$installment_qty_overwrite = $this->get_fswp_post_meta_data( $this->custom_installment_qty_key ); ?>
         <script>
             let installment_prefix = <?php echo "'" . $this->settings['installment_prefix'] . "'"; ?>;
-            let installment_qty = <?php echo $this->settings['installment_qty']; ?>;
+            let installment_qty = <?php echo empty($installment_qty_overwrite) ? $this->settings['installment_qty'] : $installment_qty_overwrite; ?>;
             let installment_suffix = <?php echo "'" . $this->settings['installment_suffix'] . "'"; ?>;
             let installment_minimum_value = <?php echo isset( $this->settings['installment_minimum_value'] ) ? str_replace( ',', '.',
 				$this->settings['installment_minimum_value'] ) : 0; ?>;
@@ -204,11 +206,14 @@ class Woocommerce_Parcelas_Public extends Woocommerce_Parcelas_Meta_Box {
 	 *
 	 * @return  void
 	 */
-	public function fswp_variable_in_cash_calculation() { ?>
+	public function fswp_variable_in_cash_calculation() {
+		// Get get_fswp_post_meta_data for in cash overwrite
+		$in_cash_discount_overwrite = $this->get_fswp_post_meta_data($this->custom_in_cash_discount_key);
+		$in_cash_discount_type_overwrite = $this->get_fswp_post_meta_data($this->custom_in_cash_discount_type_key); ?>
         <script>
             let in_cash_prefix = <?php echo "'" . $this->settings['in_cash_prefix'] . "'"; ?>;
-            let in_cash_discount = <?php echo "'" . $this->settings['in_cash_discount'] . "'"; ?>;
-            let in_cash_discount_type = <?php echo (string) $this->settings['in_cash_discount_type']; ?>;
+            let in_cash_discount = <?php echo "'" . empty($in_cash_discount_overwrite) ? $this->settings['in_cash_discount'] : $in_cash_discount_overwrite . "'"; ?>;
+            let in_cash_discount_type = <?php echo (string) empty($in_cash_discount_type_overwrite) ? $this->settings['in_cash_discount_type'] : $in_cash_discount_type_overwrite; ?>;
             let in_cash_suffix = <?php echo "'" . $this->settings['in_cash_suffix'] . "'"; ?>;
         </script>
         <div class='fswp_variable_in_cash_calculation'></div>

--- a/public/in-cash-calc.php
+++ b/public/in-cash-calc.php
@@ -10,10 +10,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$prefix         = $this->settings['in_cash_prefix'];
-$discount_value = $this->settings['in_cash_discount'];
-$discount_type  = $this->settings['in_cash_discount_type'];
-$suffix         = $this->settings['in_cash_suffix'];
+$prefix        			  = $this->settings['in_cash_prefix'];
+$discount_value_overwrite = $this->get_fswp_post_meta_data($this->custom_in_cash_discount_key);
+$discount_value			  = !isset($discount_value_overwrite) ? $this->settings['in_cash_discount'] : $discount_value_overwrite;
+$discount_type_overwrite  = $this->get_fswp_post_meta_data($this->custom_in_cash_discount_type_key);
+$discount_type 			  = !isset($discount_type_overwrite) ? $this->settings['in_cash_discount_type'] : $discount_type_overwrite;
+$suffix        			  = $this->settings['in_cash_suffix'];
 
 /**
  * @var WC_Product $product
@@ -44,7 +46,7 @@ if ( 'variable' == $product->get_type() ) {
  */
 $price = wc_get_price_including_tax( $product );
 
-$factor = str_replace( ',', '.', $discount_value );
+$factor = (float) str_replace( ',', '.', $discount_value );
 
 if ( $discount_type == 0 ) { // %
 	$factor = 1 - ( $factor / 100 );

--- a/public/installments-calc.php
+++ b/public/installments-calc.php
@@ -11,7 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $prefix       = $this->settings['installment_prefix'];
-$installments = $this->settings['installment_qty'];
+$installments_overwrite = $this->get_fswp_post_meta_data($this->custom_installment_qty_key);
+$installments = !isset($installments_overwrite) || $installments_overwrite < 2 ? $this->settings['installment_qty'] : $installments_overwrite;
 $suffix       = $this->settings['installment_suffix'];
 $min_value    = isset( $this->settings['installment_minimum_value'] ) ? str_replace( ',', '.', $this->settings['installment_minimum_value'] ) : 0;
 


### PR DESCRIPTION
Mantendo o propósito do plugin de exibir condições de pagamento personalizadas independente dos métodos de pagamentos oferecidos no checkout, implementei a possibilidade de customizar a quantidade de parcelas e/ou o desconto à vista no nível do produto, permitindo maior flexibilidade de customização.  

![image](https://github.com/filipecsweb/woocommerce-parcelas/assets/1514201/5971b2b6-e2d8-4c6c-841e-d74a5def5ca5)

É bastante útil para implementação de produto externo/afiliado, por exemplo. 

Importante lembrar que também tive que fazer algumas correções de sintaxe e funções depreciadas, pois o último release do repositório no GitHub (v1.2.8.3) não é a mesma que está no diretório de plugins do WordPress atualmente (v1.2.9.1). Portanto imagino que seja necessário realizar um merge das melhorias.

Seria ótimo entregar essa novidade para a comunidade @filipecsweb, bora publicar!